### PR TITLE
#165909178 Consume /api/v1/auth/signin endpoint using Fetch API

### DIFF
--- a/API/helpers/handlePasswordComparison.js
+++ b/API/helpers/handlePasswordComparison.js
@@ -42,6 +42,8 @@ const handlePasswordComparison = (response, accountOwner,
               firstName: accountOwner.first_name,
               lastName: accountOwner.last_name,
               email: accountOwner.email,
+              type: accountOwner.type,
+              isAdmin: accountOwner.isadmin,
             }],
           },
         );

--- a/UI/assets/js/Fetch_API/signIn.js
+++ b/UI/assets/js/Fetch_API/signIn.js
@@ -1,0 +1,51 @@
+const signInForm = document.getElementById('sign-in');
+const messageDisplay = document.getElementById('message');
+
+signInForm.onsubmit = (e) => {
+  e.preventDefault();
+  const email = document.getElementById('email');
+  const password = document.getElementById('password');
+
+  fetch('http://localhost:3000/api/v1/auth/signin', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email: email.value,
+      password: password.value,
+    }),
+  }).then(response => response.json())
+    .then((data) => {
+      if (data.data) {
+        window.sessionStorage.token = data.data[0].token;
+
+        switch (data.data[0].type) {
+          case 'client':
+            window.location.assign(
+              'file:///C:/Users/uk1/Desktop/PROJECTS/Banka/UI/dashboard.html',
+            );
+            break;
+          default:
+            console.log('hey');
+            if (data.data[0].isAdmin === true) {
+              window.location.assign(
+                'file:///C:/Users/uk1/Desktop/PROJECTS/Banka/UI/admin_dashboard.html',
+              );
+            } else {
+              window.location.assign(
+                'file:///C:/Users/uk1/Desktop/PROJECTS/Banka/UI/cashier_dashboard.html',
+              );
+            }
+            break;
+        }
+      } else {
+        messageDisplay.textContent = data.error;
+        messageDisplay.style.display = 'block';
+
+        setTimeout(() => {
+          messageDisplay.style.display = 'none';
+        }, 5000);
+      }
+    });
+};

--- a/UI/sign_in.html
+++ b/UI/sign_in.html
@@ -31,31 +31,25 @@
     <section id="login" class="container">
       <div id="login-form" class="all-form">
         <h2>Sign In</h2>
-        <form>
+        <form id="sign-in">
           <div>
-            <input type="email" placeholder="Email" pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$"
+            <input id="email" type="email" placeholder="Email" pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$"
               title="Must follow standard email format" required />
           </div>
           <div>
-            <input type="password" placeholder="Password" pattern=".{6,10}"
+            <input id="password" type="password" placeholder="Password" pattern=".{6,10}"
               title="Must be between Six(6) to Ten(10) characters" required />
           </div>
+          <button class="form-button">Login</button>
         </form>
-        <!-- I placed the button here so that it doesn't submit the form just yet,
-          but should rather serve as a link to the Dashboard page -->
-        <a href="dashboard.html"><button class="form-button">Login</button></a>
-        <a href="admin_dashboard.html">
-          <p id="admin-link">Admin? Click Here!</p>
-        </a>
-        <a href="cashier_dashboard.html">
-          <p id="admin-link">Cashier? Click Here!</p>
-        </a>
+        <p id="message"></p>
       </div>
     </section>
   </main>
   <footer>
     <p>Banka, Copyright &copy; 2019</p>
   </footer>
+  <script src="./assets/js/Fetch_API/signIn.js"></script>
 </body>
 
 </html>

--- a/test/authRoutes.js
+++ b/test/authRoutes.js
@@ -187,7 +187,7 @@ describe('AUTHENTICATION', () => {
           response.body.should.be.a('object');
           response.body.should.have.property('data');
           response.body.data[0].should.have
-            .keys('token', 'id', 'firstName', 'email', 'lastName');
+            .keys('token', 'id', 'firstName', 'email', 'lastName', 'type', 'isAdmin');
           done();
         });
     });


### PR DESCRIPTION
#### What does this PR do?
Implements front-end sign-in logic using Fetch API

#### Description of Task to be completed?
  - add client-side logic using fetch api to consume sign-in endpoint

#### How should this be manually tested?
  - clone the repo
  - set up database
  - start the server using 'npm run dev'
  - navigate to sign-in page on the browser
  - enter required sign in details and click 'Login'

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#165909178

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A