### PR TITLE
#165954793 Consume /api/v1/auth/create-staff endpoint using Fetch API

### DIFF
--- a/API/controllers/userController.js
+++ b/API/controllers/userController.js
@@ -76,7 +76,7 @@ export default class UserController {
       email, firstName, lastName, isAdmin,
     } = request.body;
 
-    bcrypt.hash(request.body.password, 10, (error, hash) => {
+    bcrypt.hash('000000', 10, (error, hash) => {
       if (error) {
         response.status(500).json({ status: 500, error });
       }

--- a/API/validations/userValidations.js
+++ b/API/validations/userValidations.js
@@ -101,16 +101,6 @@ export const staffValidation = () => [
     .withMessage('Lastname must be at least 2 characters, and maximum 15')
     .blacklist(' ')
     .customSanitizer(value => capitaliseFirstLetter(value)),
-  check('password')
-    .exists().withMessage('Password is missing')
-    .not()
-    .isEmpty({ ignore_whitespace: true })
-    .withMessage(
-      'Password cannot be blank',
-    )
-    .isLength({ min: 6, max: 128 })
-    .withMessage('Password must be at least 6 characters')
-    .blacklist(' '),
   check('isAdmin')
     .exists()
     .withMessage('Admin status is missing')

--- a/UI/assets/js/Fetch_API/createStaff.js
+++ b/UI/assets/js/Fetch_API/createStaff.js
@@ -1,0 +1,56 @@
+const createStaffForm = document.getElementById('create-staff');
+const messageDisplay = document.getElementById('message');
+
+createStaffForm.onsubmit = (e) => {
+  e.preventDefault();
+  const firstname = document.getElementById('firstName');
+  const lastname = document.getElementById('lastName');
+  const email = document.getElementById('email');
+  const type = document.querySelector('select');
+
+  let isAdmin;
+
+  if (type.value === 'cashier') {
+    isAdmin = false;
+  } else {
+    isAdmin = true;
+  }
+
+  fetch('http://localhost:3000/api/v1/auth/create-staff', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-access-token': `${window.sessionStorage.token}`,
+    },
+    body: JSON.stringify({
+      firstName: firstname.value,
+      lastName: lastname.value,
+      email: email.value,
+      isAdmin,
+    }),
+  }).then(response => response.json())
+    .then((data) => {
+      if (data.data) {
+        firstname.value = '';
+        lastname.value = '';
+        email.value = '';
+        type.value = '';
+
+
+        messageDisplay.textContent = 'Successfully created new staff';
+        messageDisplay.style.backgroundColor = '#1bb669';
+        messageDisplay.style.display = 'block';
+
+        setTimeout(() => {
+          messageDisplay.style.display = 'none';
+        }, 5000);
+      } else {
+        messageDisplay.textContent = data.error;
+        messageDisplay.style.display = 'block';
+
+        setTimeout(() => {
+          messageDisplay.style.display = 'none';
+        }, 5000);
+      }
+    });
+};

--- a/UI/cr_admin_staff.html
+++ b/UI/cr_admin_staff.html
@@ -31,17 +31,17 @@
     <section id="cr-staff-account" class="container">
       <div class="all-form">
         <h2>Create A Staff Account</h2>
-        <form>
+        <form id="create-staff">
           <div>
-            <input type="text" placeholder="First Name" name="firstname" pattern="[a-zA-Z]{2,15}"
+            <input id="firstName" type="text" placeholder="First Name" name="firstname" pattern="[a-zA-Z]{2,15}"
               title="Alphabets only. Max 15 characters" required />
           </div>
           <div>
-            <input type="text" placeholder="Last Name" name="lastname" pattern="[a-zA-Z]{2,15}"
+            <input id="lastName" type="text" placeholder="Last Name" name="lastname" pattern="[a-zA-Z]{2,15}"
               title="Alphabets only. Max 15 characters" required />
           </div>
           <div>
-            <input type="email" placeholder="Email" name="email" pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$"
+            <input id="email" type="email" placeholder="Email" name="email" pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$"
               title="Must follow standard email format" required />
           </div>
           <div>
@@ -53,12 +53,14 @@
           </div>
           <button class="form-button" type="submit">Create Account</button>
         </form>
+        <p id="message"></p>
       </div>
     </section>
   </main>
   <footer>
     <p>Banka, Copyright &copy; 2019</p>
   </footer>
+  <script src="./assets/js/Fetch_API/createStaff.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
#### What does this PR do?
Implements front-end logic for creating new staff using Fetch API

#### Description of Task to be completed?
  - add client-side logic using fetch api to consume create-new-staff endpoint

#### How should this be manually tested?
  - clone the repo
  - set up database
  - start the server using 'npm run dev'
  - navigate to create-new-staff page by signing in as an admin
  - enter required details to create new staff and click 'Create Account'

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#165954793

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A