### PR TITLE
#166039240 Consume /api/v1/auth/transactions/<accountNumber>/credit(or debit) endpoint using Fetch API

### DIFF
--- a/UI/assets/js/Fetch_API/creditDebitAccount.js
+++ b/UI/assets/js/Fetch_API/creditDebitAccount.js
@@ -1,0 +1,36 @@
+const transactionType = document.getElementById('transactionType');
+const amount = document.getElementById('amount');
+const creditDebitForm = document.getElementById('creditDebitForm');
+const balance = document.getElementById('totalBalance');
+const modal = document.getElementById('perform-transaction-overlay');
+const messageDisplay = document.getElementById('message');
+
+const { currentAccountNumber } = window.sessionStorage;
+
+creditDebitForm.onsubmit = (e) => {
+  e.preventDefault();
+  fetch(`http://localhost:3000/api/v1/transactions/${currentAccountNumber}/${transactionType.value}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-access-token': `${window.sessionStorage.token}`,
+    },
+    body: JSON.stringify({
+      amount: amount.value,
+    }),
+  }).then(response => response.json())
+    .then((data) => {
+      if (data.data) {
+        balance.innerHTML = `<span>Total Balance:</span> N${data.data[0].accountBalance}`;
+        amount.value = '';
+        modal.style.display = 'none';
+      } else {
+        messageDisplay.textContent = data.error;
+        messageDisplay.style.display = 'block';
+
+        setTimeout(() => {
+          messageDisplay.style.display = 'none';
+        }, 5000);
+      }
+    });
+};

--- a/UI/bank_account_record_cashier.html
+++ b/UI/bank_account_record_cashier.html
@@ -31,20 +31,21 @@
     <div id="perform-transaction-overlay">
       <div id="trans-overlay-content">
         <h3 class="modal-title">Credit or Debit Account <i id="close-modal" class="fas fa-times"></i></h3>
-        <form>
+        <form id="creditDebitForm">
           <div>
-            <select name="transactionType" required>
+            <select id="transactionType" name="transactionType" required>
               <option disabled selected value="">Transaction Type</option>
               <option value="credit">Credit</option>
               <option value="debit">Debit</option>
             </select>
           </div>
           <div>
-            <input type="text" placeholder="Amount" name="amount" pattern="[0-9]{1,10}" title="Max Ten(10) digits"
+            <input id="amount" type="text" placeholder="Amount" name="amount" pattern="[0-9]{1,10}" title="Max Ten(10) digits"
               required />
           </div>
           <button class="form-button" type="submit">Make Transaction</button>
         </form>
+        <p id="message"></p>
       </div>
       <div id="delete-account-modal">
         <p>Are you sure you want to delete this account?</p>
@@ -154,6 +155,7 @@
   </footer>
   <script src="./assets/js/bankAccountRecordCashierScript.js"></script>
   <script src="./assets/js/Fetch_API/accountDetails.js"></script>
+  <script src="./assets/js/Fetch_API/creditDebitAccount.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
#### What does this PR do?
Implements front-end logic for crediting or debiting bank accounts using Fetch API

#### Description of Task to be completed?
  - add client-side logic using fetch api to consume credit-debit endpoint

#### How should this be manually tested?
  - clone the repo
  - set up database
  - start the server using 'npm run dev'
  - sign-in as a cashier
  - navigate to the bank-account-record page and click the 'Credit card' icon
  - select the type of transaction, enter the amount and then click 'Make Transaction'

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#166039240

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A
